### PR TITLE
chore: change keda cooldown period from default 300s to 900s

### DIFF
--- a/src/deploy/resources/base/httpscaledobject.yml
+++ b/src/deploy/resources/base/httpscaledobject.yml
@@ -9,6 +9,7 @@ spec:
     deployment: kube-review-deployment
     service: kube-review-service
     port: 80
+  cooldownPeriod: 900
   replicas:
     min: 0
     max: 1

--- a/src/deploy/resources/base/httpscaledobject.yml
+++ b/src/deploy/resources/base/httpscaledobject.yml
@@ -9,7 +9,7 @@ spec:
     deployment: kube-review-deployment
     service: kube-review-service
     port: 80
-  cooldownPeriod: 900
+  scaledownPeriod: 900
   replicas:
     min: 0
     max: 1


### PR DESCRIPTION
In some occasions, integrated tests may mistakenly fail due to a scale down after initial deploy. 

This change will increase Keda `cooldownperiod` from default 300s to 900s.

https://keda.sh/docs/2.11/concepts/scaling-deployments/#cooldownperiod