### PR TITLE
chore: change connection test retry from 10 to 15 times

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -160,7 +160,7 @@ test_url() {
   then
     full_url=$url$test_connection_url_path
     echo "Running connection test against: $full_url"
-    output=$(curl --silent --fail --max-time 10 --retry 10 --retry-delay 5 --retry-connrefused --retry-all-errors "$full_url")
+    output=$(curl --silent --fail --max-time 10 --retry 15 --retry-delay 5 --retry-connrefused --retry-all-errors "$full_url")
     if [[ $? != 0 ]]; then
       echo "Connection test has failed with the following test output: $output";
       exit 1;


### PR DESCRIPTION
Intermittently, integrated tests within the workflow might fail mistakenly because of a Keda scale-down operation following the deployment, leading to a `curl` exit code of 28 in `test_url` within `deploy` script.

This modification will raise the retry count from 10 to 15 times.