### PR TITLE
feat: setting datadog environment variables

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/src/deploy/resources/base/deployment.yml
+++ b/src/deploy/resources/base/deployment.yml
@@ -26,6 +26,10 @@ spec:
           env:
             - name: KR_HOST
               value: "PLACEHOLDER"
+            - name: DD_SERVICE
+              value: "PLACEHOLDER"
+            - name: DD_ENV
+              value: "development"
           envFrom:
             - secretRef:
                 name: kube-review-secret

--- a/src/deploy/resources/base/patches/deployment.patch.json
+++ b/src/deploy/resources/base/patches/deployment.patch.json
@@ -11,6 +11,11 @@
     },
     {
         "op": "replace",
+        "path": "/spec/template/spec/containers/0/env/1/value", 
+        "value": "$KR_PREFIX"
+    },
+    {
+        "op": "replace",
         "path": "/spec/template/spec/containers/0/ports/0/containerPort", 
         "value": $KR_CONTAINER_PORT
     },


### PR DESCRIPTION
https://app.shortcut.com/findhotel/story/153220/adjust-datadog-service-name-from-icp-systems

ref.: https://github.com/FindHotel/daedalus/pull/12162

This PR aims to set the proper Datadog environment variables to configure the service name of the review environments; otherwise, Datadog will use the IMAGE name as the source, e.g.:

- Before:

<img width="1253" alt="Screenshot 2025-06-06 at 5 42 24 PM" src="https://github.com/user-attachments/assets/757bd821-aaa0-4524-b99e-755a77cb6b8e" />
<img width="825" alt="Screenshot 2025-06-06 at 5 40 27 PM" src="https://github.com/user-attachments/assets/99bfc911-16d2-4c8d-9aee-59d8a9decc0c" />

- After:

<img width="989" alt="Screenshot 2025-06-06 at 6 20 28 PM" src="https://github.com/user-attachments/assets/475994fa-ecf1-4132-bdf9-27928892791c" />